### PR TITLE
Fix for Yii 2.0.6

### DIFF
--- a/GraylogTarget.php
+++ b/GraylogTarget.php
@@ -70,6 +70,8 @@ class GraylogTarget extends Target
             } elseif ($text instanceof \Exception) {
                 $gelfMsg->setShortMessage('Exception ' . get_class($text) . ': ' . $text->getMessage());
                 $gelfMsg->setFullMessage((string) $text);
+                $gelfMsg->setLine($text->getLine());
+                $gelfMsg->setFile($text->getFile());
             } else {
                 // If log message contains special keys 'short', 'full' or 'add', will use them as shortMessage, fullMessage and additionals respectively
                 $short = ArrayHelper::remove($text, 'short');

--- a/GraylogTarget.php
+++ b/GraylogTarget.php
@@ -67,6 +67,9 @@ class GraylogTarget extends Target
             // For string log message set only shortMessage
             if (is_string($text)) {
                 $gelfMsg->setShortMessage($text);
+            } elseif ($text instanceof \Exception) {
+                $gelfMsg->setShortMessage('Exception ' . get_class($text) . ': ' . $text->getMessage());
+                $gelfMsg->setFullMessage((string) $text);
             } else {
                 // If log message contains special keys 'short', 'full' or 'add', will use them as shortMessage, fullMessage and additionals respectively
                 $short = ArrayHelper::remove($text, 'short');


### PR DESCRIPTION
In Yii 2.0.6 log message $text can be an \Exception

See https://github.com/yiisoft/yii2/blob/2.0.6/framework/CHANGELOG.md, Chg #6354
